### PR TITLE
Add Token Authentication through HTTP Authorization header

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ $ WGAPI_TOKENS=<random string> wg-api --device=<my device>
 
 Then provided as part of the HTTP exchange in the HTTP `Authorization` header as the `Token` scheme.
 
+```sh
+$ curl http://localhost:8080 -H "Authorization: Token <random string>" ...
+```
+
 ```
 POST / HTTP/1.1
 Host: localhost:8080

--- a/cmd/wg-api.go
+++ b/cmd/wg-api.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -14,6 +13,7 @@ import (
 	"github.com/jamescun/wg-api/server"
 	"github.com/jamescun/wg-api/server/jsonrpc"
 
+	flag "github.com/spf13/pflag"
 	"golang.zx2c4.com/wireguard/wgctrl"
 )
 

--- a/cmd/wg-api.go
+++ b/cmd/wg-api.go
@@ -45,6 +45,7 @@ Warnings:
   WG-API can perform sensitive network operations, as such it should not be
   publicly exposed. It should be bound to the local interface only, or
   failing that, be behind an authenticating proxy or have mTLS enabled.
+  Additionally authentication tokens should be configured.
 `
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/jamescun/wg-api
 
 go 1.13
 
-require golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200205215550-e35592f146e4
+require (
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200205215550-e35592f146e4
+)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/jamescun/wg-api
 go 1.13
 
 require (
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200205215550-e35592f146e4
 )

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/mdlayher/netlink v1.1.0 h1:mpdLgm+brq10nI9zM1BpX1kpDbh3NLl3RSnVq6ZSkf
 github.com/mdlayher/netlink v1.1.0/go.mod h1:H4WCitaheIsdF9yOYu8CFmCgQthAPIWZmcKp9uZHgmY=
 github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721 h1:RlZweED6sbSArvlE924+mUcZuXKLBHA35U7LN621Bws=
 github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721/go.mod h1:Ickgr2WtCLZ2MDGd4Gr0geeCH5HybhRJbonOgQpvSxc=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72 h1:+ELyKg6m8UBf0nPFSqD0mi7zUfwPyXo23HNjMnXPz7w=


### PR DESCRIPTION
Adds support for passing in multiple tokens, either by command line argument or environment variables, that are required in the `Authorization` header before WG-API will execute the request.

Adding the environment variable was a little hacky, seek to refactor this á la issue #4. Middleware construction also may need to be refactored.

Fixes #2 